### PR TITLE
Corrigido bug no botão de status do GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Uma biblioteca profissional de ícones para linguagens, frameworks e ferramentas
 
 **CoreIcons Library** é um catálogo público de ícones técnicos para stacks e ferramentas dev. Inclui recursos de pesquisa, pré-visualização 3D e URLs para uso em documentação e projetos.
 
-- **Versão:** 1.0.4
+- **Versão:** 1.0.5
 - **Proprietário:** Maurício Spark
 - **Marca:** Spark
 - **Linhagem:** SPARK
@@ -22,6 +22,7 @@ Uma biblioteca profissional de ícones para linguagens, frameworks e ferramentas
 - **URLs públicas** para uso em documentação
 - **API JavaScript** para integração em projetos
 - **Suporte a atalhos de teclado** (Ctrl+K para pesquisa)
+- **Botão de estrelas do GitHub** com contagem em tempo real
 
 ## Estrutura do Projeto
 

--- a/css/style.css
+++ b/css/style.css
@@ -119,6 +119,43 @@ body {
   max-width: 100%;
 }
 
+.header-stars {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 8px 14px;
+  font-size: 0.8125rem;
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(51, 65, 85, 0.8);
+  backdrop-filter: blur(8px);
+}
+
+.header-stars:hover {
+  background: rgba(51, 65, 85, 0.9);
+  border-color: var(--primary);
+  transform: translateY(-50%) translateY(-2px);
+}
+
+.header-stars svg {
+  width: 14px;
+  height: 14px;
+}
+
+.header-stars .github-icon {
+  color: var(--text-muted);
+  transition: color 0.2s ease;
+}
+
+.header-stars .star-icon {
+  color: var(--accent-gold);
+  margin-left: 2px;
+}
+
+.header-stars:hover .github-icon {
+  color: var(--text);
+}
+
 .subtitle {
   font-size: clamp(0.9375rem, 2.5vw, 1.0625rem);
   font-weight: 500;
@@ -189,6 +226,47 @@ body {
   font-size: 0.75rem;
   color: var(--text-muted);
   border: 1px solid var(--border);
+}
+
+.github-stars-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin: 0 auto;
+}
+
+.github-stars-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--primary);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+.github-stars-btn:active {
+  transform: translateY(0);
+}
+
+.github-stars-btn svg {
+  color: var(--text-muted);
+  transition: color 0.2s ease;
+}
+
+.github-stars-btn:hover svg {
+  color: var(--accent-gold);
+}
+
+#github-stars-count {
+  font-weight: 600;
+  color: var(--text);
 }
 
 .toolbar {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,21 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 
+## [1.0.5] - 2026-07-19
+
+### Adicionado
+
+- **Botão de estrelas do GitHub** no header com contagem em tempo real
+- Design com ícone do GitHub e estrela dourada
+- Integração com API do GitHub para busca de estrelas
+- Click no botão abre o repositório no GitHub
+
+### Alterado
+
+- Atualização do README.md para documentar nova funcionalidade
+
+---
+
 ## [1.0.4] - 2026-07-17
 
 ### Adicionado

--- a/index.html
+++ b/index.html
@@ -43,18 +43,22 @@
   <header class="header">
     <div class="container header-inner">
       <div class="header-glow" aria-hidden="true"></div>
+      <button id="github-stars-btn" class="github-stars-btn header-stars" title="Ver estrelas no GitHub">
+        <svg class="github-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path
+            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+        </svg>
+        <svg class="star-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+        </svg>
+        <span id="github-stars-count">Carregando...</span>
+      </button>
       <h1 class="brand-heading">
         <img class="brand-logo" src="favicon/coreicons.png" width="200" height="80" alt="CoreIcons Library"
           decoding="async" fetchpriority="high">
       </h1>
-      <a href="https://github.com/mauriciospark/coreIcons" target="_blank" rel="noopener noreferrer"
-        class="header-badge">
-        <img src="https://img.shields.io/github/stars/mauriciospark/coreIcons?style=social" alt="GitHub Stars"
-          loading="lazy">
-      </a>
     </div>
   </header>
-
   <main class="container">
     <div class="search-section">
       <div class="search-box">

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -68,6 +68,7 @@
     setupModalListeners();
     updateIconCount();
     renderIcons();
+    fetchGitHubStars();
   }
 
   function loadIcons() {
@@ -415,6 +416,30 @@
     } else {
       resultsCount.textContent = 'Total: ' + count + ' ícones';
     }
+  }
+
+  function fetchGitHubStars() {
+    var starsBtn = document.getElementById('github-stars-btn');
+    var starsCount = document.getElementById('github-stars-count');
+
+    if (!starsBtn || !starsCount) return;
+
+    fetch('https://api.github.com/repos/mauriciospark/coreIcons')
+      .then(function (response) {
+        if (!response.ok) throw new Error('Erro ao buscar estrelas');
+        return response.json();
+      })
+      .then(function (data) {
+        var stars = data.stargazers_count;
+        starsCount.textContent = stars + ' estrela' + (stars !== 1 ? 's' : '');
+      })
+      .catch(function (error) {
+        starsCount.textContent = '★ GitHub';
+      });
+
+    starsBtn.addEventListener('click', function () {
+      window.open('https://github.com/mauriciospark/coreIcons', '_blank');
+    });
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive GitHub Stars button to the header.
  * Displays the repository’s current star count in real time.
  * Opens the project repository in a new browser tab when selected.
  * Added visual feedback for hover and active states.
  * Provides a fallback display when the star count cannot be retrieved.

* **Documentation**
  * Updated the README and changelog for version 1.0.5.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->